### PR TITLE
Fix subscribable value class

### DIFF
--- a/Runtime/Utils/Values/SubscribableValue.cs
+++ b/Runtime/Utils/Values/SubscribableValue.cs
@@ -7,6 +7,7 @@ namespace Padoru.Core
 	{
 		private T value;
 
+		[field: NonSerialized]
 		public event Action<T> OnValueChanged;
 
 		public T Value

--- a/Runtime/Utils/Values/SubscribableValue.cs
+++ b/Runtime/Utils/Values/SubscribableValue.cs
@@ -8,7 +8,7 @@ namespace Padoru.Core
 		private T value;
 
 		[field: NonSerialized]
-		public event Action<T> OnValueChanged;
+		private event Action<T> OnValueChanged;
 
 		/// <summary>
 		/// Value property that invoke the OnValueChanged event when the value is set.

--- a/Runtime/Utils/Values/SubscribableValue.cs
+++ b/Runtime/Utils/Values/SubscribableValue.cs
@@ -22,11 +22,7 @@ namespace Padoru.Core
 				
 				this.value = value;
 
-				// The '?' operator doesn't work with the serialization
-				if (OnValueChanged != null)
-				{
-					OnValueChanged.Invoke(this.value);
-				}
+				OnValueChanged?.Invoke(this.value);
 			}
 		}
 

--- a/Runtime/Utils/Values/SubscribableValue.cs
+++ b/Runtime/Utils/Values/SubscribableValue.cs
@@ -12,12 +12,14 @@ namespace Padoru.Core
 
 		public T Value
 		{
-			get
-			{
-				return value;
-			}
+			get => value;
 			set
 			{
+				if (Equals(this.value, value))
+				{
+					return;
+				}
+				
 				this.value = value;
 
 				// The '?' operator doesn't work with the serialization
@@ -31,6 +33,30 @@ namespace Padoru.Core
 		public SubscribableValue(T initialValue)
 		{
 			value = initialValue;
+		}
+		
+		public Action SubscribeAndInvoke(Action<T> subscriber)
+		{
+			OnValueChanged += subscriber;
+			subscriber.Invoke(value);
+
+			return () => OnValueChanged -= subscriber;
+		}
+		
+		public Action Subscribe(Action<T> subscriber)
+		{
+			OnValueChanged += subscriber;
+            
+			return () => OnValueChanged -= subscriber;
+		}
+		
+		/// <summary>
+		/// Set value and invoke OnValueChanged without checking for changes.
+		/// </summary>
+		public void ForceValueChange(T newValue)
+		{
+			value = newValue;
+			OnValueChanged?.Invoke(newValue);
 		}
 	}
 }

--- a/Runtime/Utils/Values/SubscribableValue.cs
+++ b/Runtime/Utils/Values/SubscribableValue.cs
@@ -10,19 +10,24 @@ namespace Padoru.Core
 		[field: NonSerialized]
 		public event Action<T> OnValueChanged;
 
+		/// <summary>
+		/// Value property that invoke the OnValueChanged event when the value is set.
+		/// If you set the same value the OnValueChanged event is not invoked.
+		/// </summary>
 		public T Value
 		{
-			get => value;
+			get
+			{
+				return value;
+			}
 			set
 			{
 				if (Equals(this.value, value))
 				{
 					return;
 				}
-				
-				this.value = value;
 
-				OnValueChanged?.Invoke(this.value);
+				SetValueAndInvoke(value);
 			}
 		}
 
@@ -31,6 +36,9 @@ namespace Padoru.Core
 			value = initialValue;
 		}
 		
+		/// <summary>
+		/// Subscribe to value changes and invoke the given subscriber immediately. Return the unsubscribe action.
+		/// </summary>
 		public Action SubscribeAndInvoke(Action<T> subscriber)
 		{
 			OnValueChanged += subscriber;
@@ -39,6 +47,11 @@ namespace Padoru.Core
 			return () => OnValueChanged -= subscriber;
 		}
 		
+		/// <summary>
+		/// Subscribe to value changes and return the unsubscribe action.
+		/// </summary>
+		/// <param name="subscriber"></param>
+		/// <returns></returns>
 		public Action Subscribe(Action<T> subscriber)
 		{
 			OnValueChanged += subscriber;
@@ -51,8 +64,13 @@ namespace Padoru.Core
 		/// </summary>
 		public void ForceValueChange(T newValue)
 		{
+			SetValueAndInvoke(newValue);
+		}
+
+		private void SetValueAndInvoke(T newValue)
+		{
 			value = newValue;
-			OnValueChanged?.Invoke(newValue);
+			OnValueChanged?.Invoke(value);
 		}
 	}
 }


### PR DESCRIPTION
- I fix a serialization error with the Action. Now is NonSerialized.
- I add Subscribe methods to the class
- Now if the value setted is the same, the event is not invoked (we can force the invoke with the ForceValueChanged method)